### PR TITLE
Added missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "joblib>=1.4.2",
     "duckdb>=1.4.2",
     "tqdm>=4.67.1",
+    "pyyaml>=6.0.2",
+    "requests>=2.32.3",
 ]
 readme = "README.md"
 requires-python = ">= 3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -406,7 +406,7 @@ wheels = [
 
 [[package]]
 name = "isp-trace-parser"
-version = "1.0.3"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -414,6 +414,8 @@ dependencies = [
     { name = "pandas" },
     { name = "polars" },
     { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
 ]
 
@@ -437,6 +439,8 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.2" },
     { name = "polars", specifier = ">=1.7.1" },
     { name = "pydantic", specifier = ">=2.9.2" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "requests", specifier = ">=2.32.3" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
 


### PR DESCRIPTION
Added some dependencies (that somehow dropped out of the pyproject.toml)

Seems that `uv sync` is adding some transitive dependencies  (e.g. things like `pyyaml`, `requests`) - so wasn't picked up in uv workflow (.. but also not sure why `pyyaml` wasn't already there). 